### PR TITLE
GDCquery_Maf PUBMED and SOMATIC coltypes

### DIFF
--- a/R/TCGAQuery.R
+++ b/R/TCGAQuery.R
@@ -520,7 +520,7 @@ GDCquery_Maf <- function(tumor, save.csv= FALSE, directory = "GDCdata"){
                             PICK = col_integer(),
                             TSL = col_integer(),
                             HGVS_OFFSET = col_integer(),
-                            MINIMISED = col_integer()),
+                            MINIMISED = col_integer(),PUBMED= col_character(),SOMATIC= col_character()),
                         progress = TRUE)
         if(ncol(ret) == 1) ret <- read_csv(file,
                                            comment = "#",
@@ -537,7 +537,7 @@ GDCquery_Maf <- function(tumor, save.csv= FALSE, directory = "GDCdata"){
                                                PICK = col_integer(),
                                                TSL = col_integer(),
                                                HGVS_OFFSET = col_integer(),
-                                               MINIMISED = col_integer()),
+                                               MINIMISED = col_integer(),PUBMED= col_character(),SOMATIC= col_character()),
                                            progress = TRUE)
         ret
     })

--- a/R/TCGAQuery.R
+++ b/R/TCGAQuery.R
@@ -520,7 +520,9 @@ GDCquery_Maf <- function(tumor, save.csv= FALSE, directory = "GDCdata"){
                             PICK = col_integer(),
                             TSL = col_integer(),
                             HGVS_OFFSET = col_integer(),
-                            MINIMISED = col_integer(),PUBMED= col_character(),SOMATIC= col_character()),
+                            MINIMISED = col_integer(),
+                            PUBMED= col_character(),
+                            SOMATIC= col_character()),
                         progress = TRUE)
         if(ncol(ret) == 1) ret <- read_csv(file,
                                            comment = "#",
@@ -537,7 +539,9 @@ GDCquery_Maf <- function(tumor, save.csv= FALSE, directory = "GDCdata"){
                                                PICK = col_integer(),
                                                TSL = col_integer(),
                                                HGVS_OFFSET = col_integer(),
-                                               MINIMISED = col_integer(),PUBMED= col_character(),SOMATIC= col_character()),
+                                               MINIMISED = col_integer(),
+                                               PUBMED= col_character(),
+                                               SOMATIC= col_character()),
                                            progress = TRUE)
         ret
     })


### PR DESCRIPTION
After using the package i find that the wraper read_tsv function inside the GDCquery_Maf function had some problems with the SOMATIC and PUBMED columns in the BRCA data (discarded some rows when finding numbers with commas in those columns), I corrected the issue just adding coltypes for this two columns.

Hope is usefull
